### PR TITLE
Using application context in `MediaPlayer#setDataSource()` 

### DIFF
--- a/library/src/main/java/com/sprylab/android/widget/TextureVideoView.java
+++ b/library/src/main/java/com/sprylab/android/widget/TextureVideoView.java
@@ -284,7 +284,7 @@ public class TextureVideoView extends TextureView
             mMediaPlayer.setOnInfoListener(mInfoListener);
             mMediaPlayer.setOnBufferingUpdateListener(mBufferingUpdateListener);
             mCurrentBufferPercentage = 0;
-            mMediaPlayer.setDataSource(mContext, mUri, mHeaders);
+            mMediaPlayer.setDataSource(mContext.getApplicationContext(), mUri, mHeaders);
             mMediaPlayer.setSurface(mSurface);
             mMediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
             mMediaPlayer.setScreenOnWhilePlaying(true);


### PR DESCRIPTION
Using application context in `MediaPlayer#setDataSource()` to avoid potential Activity leaks.
On Android 4.4.4 (maybe also older versions) `Context` used in `MediaPlayer#setDataSource()` is saved when URI scheme is http(s) which may cause `Activity` leaks.
Reference:
http://grepcode.com/file/repository.grepcode.com/java/ext/com.google.android/android/4.4.4_r1/android/media/MediaPlayer.java#MediaPlayer.setupProxyListener%28android.content.Context%29
