### PR TITLE
Use application context for audio manager

### DIFF
--- a/library/src/main/java/com/sprylab/android/widget/TextureVideoView.java
+++ b/library/src/main/java/com/sprylab/android/widget/TextureVideoView.java
@@ -256,7 +256,7 @@ public class TextureVideoView extends TextureView
             mMediaPlayer = null;
             mCurrentState = STATE_IDLE;
             mTargetState  = STATE_IDLE;
-            AudioManager am = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
+            AudioManager am = (AudioManager) getContext().getApplicationContext().getSystemService(Context.AUDIO_SERVICE);
             am.abandonAudioFocus(null);
         }
     }
@@ -270,7 +270,7 @@ public class TextureVideoView extends TextureView
         // called start() previously
         release(false);
 
-        AudioManager am = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
+        AudioManager am = (AudioManager) getContext().getApplicationContext().getSystemService(Context.AUDIO_SERVICE);
         am.requestAudioFocus(null, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
 
         try {
@@ -566,7 +566,7 @@ public class TextureVideoView extends TextureView
             if (cleartargetstate) {
                 mTargetState  = STATE_IDLE;
             }
-            AudioManager am = (AudioManager) getContext().getSystemService(Context.AUDIO_SERVICE);
+            AudioManager am = (AudioManager) getContext().getApplicationContext().getSystemService(Context.AUDIO_SERVICE);
             am.abandonAudioFocus(null);
         }
     }


### PR DESCRIPTION
This is something that's fixed in AOSP but will still happen on older versions of android (pre-6.0). I know you want to keep this implementation clean as a copy, but this would only be beneficial.

http://stackoverflow.com/questions/6445052/android-context-memory-leak-listview-due-to-audiomanager

https://code.google.com/p/android/issues/detail?id=152173

https://android-review.googlesource.com/#/c/140481/1/media/java/android/media/AudioManager.java
